### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
     "project_name": ""
   },
   "description": "Import Point Cloud Project with Annotations and Photo context in Supervisely format",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/import-export:6.73.564",
   "task_location": "workspace_tasks",
   "modal_template": "src/modal.html",
   "main_script": "src/main.py",

--- a/config.json
+++ b/config.json
@@ -17,7 +17,7 @@
   "headless": true,
   "isolate": true,
   "min_agent_version": "6.7.4",
-  "min_instance_version": "6.15.40",
+  "instance_version": "6.15.60",
   "context_menu": {
     "context_category": "Import",
     "target": ["files_folder", "files_file", "agent_folder", "agent_file"]

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "project_name": ""
   },
   "description": "Import Point Cloud Project with Annotations and Photo context in Supervisely format",
-  "docker_image": "supervisely/import-export:6.73.511",
+  "docker_image": "supervisely/import-export:6.73.564",
   "task_location": "workspace_tasks",
   "modal_template": "src/modal.html",
   "main_script": "src/main.py",

--- a/config.json
+++ b/config.json
@@ -1,13 +1,17 @@
 {
   "name": "Import Point Cloud Project",
   "type": "app",
-  "categories": ["import", "pointclouds", "essentials"],
+  "categories": [
+    "import",
+    "pointclouds",
+    "essentials"
+  ],
   "modal_template_state": {
     "remove_source": true,
     "project_name": ""
   },
   "description": "Import Point Cloud Project with Annotations and Photo context in Supervisely format",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "task_location": "workspace_tasks",
   "modal_template": "src/modal.html",
   "main_script": "src/main.py",
@@ -20,7 +24,12 @@
   "instance_version": "6.15.60",
   "context_menu": {
     "context_category": "Import",
-    "target": ["files_folder", "files_file", "agent_folder", "agent_file"]
+    "target": [
+      "files_folder",
+      "files_file",
+      "agent_folder",
+      "agent_file"
+    ]
   },
   "poster": "https://github.com/supervisely-ecosystem/import-pointcloud-project/releases/download/v0.0.0/import_ptc_poster.png"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.511
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
